### PR TITLE
Potential fix for code scanning alert no. 12: Flask app is run in debug mode

### DIFF
--- a/backend/inventory-api/src/main.py
+++ b/backend/inventory-api/src/main.py
@@ -85,4 +85,5 @@ def serve(path):
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    debug_mode = os.environ.get('FLASK_DEBUG', '0').lower() in ('1', 'true', 'yes')
+    app.run(host='0.0.0.0', port=5000, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/chronie-shizutoki/smart-inventory-manager/security/code-scanning/12](https://github.com/chronie-shizutoki/smart-inventory-manager/security/code-scanning/12)

To fix this issue, the Flask application should not be run with `debug=True` unconditionally. The best practice is to control the debug mode via an environment variable (such as `FLASK_DEBUG` or a custom variable), or to set `debug=False` by default and only enable it explicitly for development. This ensures that in production environments, debug mode is never enabled accidentally.

The recommended fix is to modify the `if __name__ == '__main__':` block in `backend/inventory-api/src/main.py` to check an environment variable (e.g., `FLASK_DEBUG`) and only enable debug mode if it is set to `'1'` or `'true'`. Otherwise, run the app with `debug=False` (the default). This change is limited to the last few lines of the file.

No new imports are needed, as `os` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
