### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/backend/inventory-api/src/main.py
+++ b/backend/inventory-api/src/main.py
@@ -72,9 +72,12 @@ with app.app_context():
 def serve(path):
     static_folder_path = app.static_folder
     if static_folder_path is None:
-            return "Static folder not configured", 404
+        return "Static folder not configured", 404
 
-    if path != "" and os.path.exists(os.path.join(static_folder_path, path)):
+    # Normalize and validate the path to prevent path traversal
+    requested_path = os.path.normpath(os.path.join(static_folder_path, path))
+    if path != "" and requested_path.startswith(static_folder_path) and os.path.exists(requested_path):
+        # Only serve if the normalized path is within the static folder
         return send_from_directory(static_folder_path, path)
     else:
         index_path = os.path.join(static_folder_path, 'index.html')


### PR DESCRIPTION
Potential fix for [https://github.com/chronie-shizutoki/smart-inventory-manager/security/code-scanning/11](https://github.com/chronie-shizutoki/smart-inventory-manager/security/code-scanning/11)

To fix the problem, we need to ensure that any path constructed from user input is validated before being used to access the filesystem. The best way is to normalize the joined path using `os.path.normpath`, and then check that the resulting path is still within the intended static folder. This prevents path traversal attacks using `..` or absolute paths. The fix should be applied in the `serve` function, specifically where `os.path.join(static_folder_path, path)` is used. We should also ensure that the normalized path is not outside the static folder before serving the file. No new methods are needed, but we should add the normalization and containment check before calling `send_from_directory`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
